### PR TITLE
Fix: Close Login Modal Without Redirecting to Main Page

### DIFF
--- a/src/components/layout/login-modal.tsx
+++ b/src/components/layout/login-modal.tsx
@@ -16,7 +16,7 @@ export default function LoginModal() {
   const IsOpen = pathname.includes("/login");
 
   return (
-    <Dialog open={IsOpen} onOpenChange={() => router.push("/")}>
+    <Dialog open={IsOpen} onOpenChange={() => router.back()}>
       <DialogContent className="w-full max-w-[400px] rounded-md">
         <DialogHeader>
           <DialogTitle>


### PR DESCRIPTION
**Description:**
This PR addresses the issue where closing the login modal redirects users to the main page. The change ensures that users remain on the current page after closing the dialog, providing a more intuitive user experience. This PR fixes #237 

**Changes:**
- Updated `onOpenChange` in `LoginModal` component to use `router.back()` instead of `router.push("/")`.

**Affected Files:**
- `src/components/layout/login-modal.tsx`

**Testing:**
1. Navigate to any page other than the main page.
2. Click the "Login" button to open the login modal.
3. Click the "x" button in the upper right corner of the dialog.
4. Verify that the dialog closes and the user remains on the current page.