### PR TITLE
fix: add empty turbopack config for Next.js 16 compatibility

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -25,6 +25,8 @@ const nextConfig = {
   eslint: {
     ignoreDuringBuilds: true,
   },
+  // Required for Next.js 16+ when webpack config is added by plugins like @serwist/next
+  turbopack: {},
 }
 
 export default withSerwist(nextConfig);


### PR DESCRIPTION
Next.js 16 enables Turbopack by default and requires explicit turbopack config when webpack config is present (added by @serwist/next plugin).