### PR TITLE
feat: add Mailtrap as a selectable email provider (with Sandbox for local dev)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Save time and effort, and build performant apps with an excellent developer expe
 4. Run `pnpm prisma db push` to set up the database.
 5. Start the dev server: `pnpm dev`
 
+> 💡 **Email providers.** Emails are sent via [Resend](https://resend.com/) by default. You can switch to [Mailtrap](https://mailtrap.io/) — a Resend alternative — by setting `EMAIL_PROVIDER=mailtrap` (plus `MAILTRAP_API_TOKEN`). Live Mailtrap sending requires a verified sending domain and a matching `FROM` address (set in `src/lib/server/mail.ts`). For local development, set `USE_MAILTRAP_SANDBOX=true` (plus `MAILTRAP_API_TOKEN` and `MAILTRAP_INBOX_ID`) to route all emails to a Mailtrap Sandbox test inbox instead of delivering them — no domain setup needed, and no spamming real inboxes or burning Resend quota while building.
+
 ### Or
 
 [![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fmoinulmoin%2Fchadnext&env=DB_PRISMA_URL,DB_URL_NON_POOLING,GITHUB_CLIENT_ID,GITHUB_CLIENT_SECRET,NEXTAUTH_SECRET,NEXT_PUBLIC_APP_URL,RESEND_API_KEY,UPLOADTHING_SECRET,UPLOADTHING_APP_ID,UPLOADTHING_URL)

--- a/example.env
+++ b/example.env
@@ -13,6 +13,24 @@ UPLOADTHING_URL="http://localhost:3000"
 # Create an account in resend and get the api key https://resend.com/
 RESEND_API_KEY=
 
+# Email provider. Defaults to "resend". Set EMAIL_PROVIDER=mailtrap to send via
+# Mailtrap (https://mailtrap.io/) instead — a Resend alternative that also offers a
+# Sandbox for local testing. Note: live Mailtrap sending requires a verified sending
+# domain and a matching FROM address (update FROM in src/lib/server/mail.ts); for local
+# testing without a domain, use USE_MAILTRAP_SANDBOX below instead.
+EMAIL_PROVIDER=resend
+
+# Shortcut for local development: set USE_MAILTRAP_SANDBOX=true to route emails to a
+# Mailtrap Sandbox test inbox instead of delivering them. Emails are captured, never
+# sent to real recipients, so you can develop without spamming inboxes or spending
+# Resend quota. This overrides EMAIL_PROVIDER and requires MAILTRAP_INBOX_ID.
+# Grab your API token + sandbox inbox id from https://mailtrap.io/
+# (Sandboxes > open your sandbox > copy the ID from the URL).
+USE_MAILTRAP_SANDBOX=false
+MAILTRAP_API_TOKEN=
+# Only needed when USE_MAILTRAP_SANDBOX=true.
+MAILTRAP_INBOX_ID=
+
 # Create a project in uploadthing and get api keys https://uploadthing.com/
 UPLOADTHING_SECRET=
 UPLOADTHING_APP_ID=

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "embla-carousel-react": "^8.5.2",
     "input-otp": "^1.4.2",
     "lucide-react": "^0.471.1",
+    "mailtrap": "^4.6.1",
     "next": "16.0.10",
     "next-international": "^1.3.1",
     "next-safe-action": "^7.10.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -131,6 +131,9 @@ importers:
       lucide-react:
         specifier: ^0.471.1
         version: 0.471.1(react@19.2.3)
+      mailtrap:
+        specifier: ^4.6.1
+        version: 4.6.1
       next:
         specifier: 16.0.10
         version: 16.0.10(@babel/core@7.24.5)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -2648,6 +2651,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  agent-base@6.0.2:
+    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
+    engines: {node: '>= 6.0.0'}
+
   agent-base@7.1.3:
     resolution: {integrity: sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==}
     engines: {node: '>= 14'}
@@ -2780,6 +2787,9 @@ packages:
   async-retry@1.3.3:
     resolution: {integrity: sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==}
 
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
   atomically@2.0.3:
     resolution: {integrity: sha512-kU6FmrwZ3Lx7/7y3hPS5QnbJfaohcIul5fGqf7ok+4KklIEk9tJ0C2IQPdacSbVUWv6zVHXEBWoWd6NrVMT7Cw==}
 
@@ -2797,6 +2807,9 @@ packages:
   axe-core@4.10.3:
     resolution: {integrity: sha512-Xm7bpRXnDSX2YE2YFfBk2FnF0ep6tmG7xPh8iHee8MIcrgq762Nkce856dYtJYLkuIoYZvGfTs/PbZhideTcEg==}
     engines: {node: '>=4'}
+
+  axios@1.18.1:
+    resolution: {integrity: sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==}
 
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
@@ -2904,20 +2917,12 @@ packages:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
 
-  call-bind-apply-helpers@1.0.1:
-    resolution: {integrity: sha512-BhYE+WDaywFg2TBWYNXAE+8B1ATnThNBqXHP5nQu0jWJdVvY2hvkpyB3qOmtmDePiS5/BDQ8wASEWGMWRG148g==}
-    engines: {node: '>= 0.4'}
-
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
 
   call-bind@1.0.8:
     resolution: {integrity: sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==}
-    engines: {node: '>= 0.4'}
-
-  call-bound@1.0.3:
-    resolution: {integrity: sha512-YTd+6wGlNlPxSuri7Y6X8tY2dmm12UMH66RpKMhiX6rsk5wXXnYgbUcOt8kiS31/AjfoTOvCsE+w8nZQLQnzHA==}
     engines: {node: '>= 0.4'}
 
   call-bound@1.0.4:
@@ -3063,6 +3068,10 @@ packages:
 
   colorette@2.0.20:
     resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
+
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
 
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
@@ -3328,6 +3337,10 @@ packages:
   degenerator@5.0.1:
     resolution: {integrity: sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==}
     engines: {node: '>= 14'}
+
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
 
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
@@ -3808,6 +3821,15 @@ packages:
   flatted@3.3.3:
     resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
 
+  follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
@@ -3815,6 +3837,10 @@ packages:
   foreground-child@3.3.0:
     resolution: {integrity: sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==}
     engines: {node: '>=14'}
+
+  form-data@4.0.6:
+    resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
+    engines: {node: '>= 6'}
 
   fraction.js@4.3.7:
     resolution: {integrity: sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==}
@@ -3848,10 +3874,6 @@ packages:
   get-east-asian-width@1.3.0:
     resolution: {integrity: sha512-vpeMIQKxczTD/0s2CdEWHcb0eeJe6TFjxb+J5xgX7hScxqrGuyjmv4c1D4A/gelKfyox0gJJwIHF+fLjeaM8kQ==}
     engines: {node: '>=18'}
-
-  get-intrinsic@1.2.7:
-    resolution: {integrity: sha512-VW6Pxhsrk0KAOqs3WEd0klDiF/+V7gQOpAvY1jVU/LHmaD/kQO4523aiJuikX/QAKYiW6x8Jh+RJej1almdtCA==}
-    engines: {node: '>= 0.4'}
 
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
@@ -3983,6 +4005,10 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
+    engines: {node: '>= 0.4'}
+
   hast-util-to-estree@3.1.1:
     resolution: {integrity: sha512-IWtwwmPskfSmma9RpzCappDUitC8t5jhAynHhc1m2+5trOgsrp7txscUSavc5Ic8PATyAjfrCK1wgtxh2cICVQ==}
 
@@ -4008,6 +4034,10 @@ packages:
   http-proxy-agent@7.0.2:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
     engines: {node: '>= 14'}
+
+  https-proxy-agent@5.0.1:
+    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
+    engines: {node: '>= 6'}
 
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
@@ -4568,6 +4598,18 @@ packages:
   macos-release@3.3.0:
     resolution: {integrity: sha512-tPJQ1HeyiU2vRruNGhZ+VleWuMQRro8iFtJxYgnS4NQe+EukKF6aGiIT+7flZhISAt2iaXBCfFGvAyif7/f8nQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  mailtrap@4.6.1:
+    resolution: {integrity: sha512-mObbFhDhpxZvSkDzIPch3lYQ/3m1y2oDr3Vg/YbFHlG6SDb4khCqhb8DkMwdm9heE+mLCzbCjnX6cJIYMAJM+g==}
+    engines: {node: '>=16.20.1', yarn: '>=1.22.17'}
+    peerDependencies:
+      '@types/nodemailer': ^6.4.9
+      nodemailer: ^9.0.1
+    peerDependenciesMeta:
+      '@types/nodemailer':
+        optional: true
+      nodemailer:
+        optional: true
 
   markdown-extensions@2.0.0:
     resolution: {integrity: sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q==}
@@ -5301,6 +5343,10 @@ packages:
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
+  proxy-from-env@2.1.0:
+    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
+    engines: {node: '>=10'}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -5314,6 +5360,10 @@ packages:
 
   qs@6.14.0:
     resolution: {integrity: sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==}
+    engines: {node: '>=0.6'}
+
+  qs@6.15.3:
+    resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
     engines: {node: '>=0.6'}
 
   queue-microtask@1.2.3:
@@ -5667,6 +5717,10 @@ packages:
     resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
     engines: {node: '>= 0.4'}
 
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
+    engines: {node: '>= 0.4'}
+
   side-channel-map@1.0.1:
     resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
     engines: {node: '>= 0.4'}
@@ -5677,6 +5731,10 @@ packages:
 
   side-channel@1.1.0:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.1:
+    resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
     engines: {node: '>= 0.4'}
 
   signal-exit@3.0.7:
@@ -8646,6 +8704,12 @@ snapshots:
 
   acorn@8.14.1: {}
 
+  agent-base@6.0.2:
+    dependencies:
+      debug: 4.4.1
+    transitivePeerDependencies:
+      - supports-color
+
   agent-base@7.1.3: {}
 
   ajv-formats@2.1.1(ajv@8.17.1):
@@ -8812,6 +8876,8 @@ snapshots:
     dependencies:
       retry: 0.13.1
 
+  asynckit@0.4.0: {}
+
   atomically@2.0.3:
     dependencies:
       stubborn-fs: 1.2.5
@@ -8832,6 +8898,16 @@ snapshots:
       possible-typed-array-names: 1.1.0
 
   axe-core@4.10.3: {}
+
+  axios@1.18.1:
+    dependencies:
+      follow-redirects: 1.16.0
+      form-data: 4.0.6
+      https-proxy-agent: 5.0.1
+      proxy-from-env: 2.1.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
 
   axobject-query@4.1.0: {}
 
@@ -8966,11 +9042,6 @@ snapshots:
 
   cac@6.7.14: {}
 
-  call-bind-apply-helpers@1.0.1:
-    dependencies:
-      es-errors: 1.3.0
-      function-bind: 1.1.2
-
   call-bind-apply-helpers@1.0.2:
     dependencies:
       es-errors: 1.3.0
@@ -8982,11 +9053,6 @@ snapshots:
       es-define-property: 1.0.1
       get-intrinsic: 1.3.0
       set-function-length: 1.2.2
-
-  call-bound@1.0.3:
-    dependencies:
-      call-bind-apply-helpers: 1.0.1
-      get-intrinsic: 1.2.7
 
   call-bound@1.0.4:
     dependencies:
@@ -9140,6 +9206,10 @@ snapshots:
       color-string: 1.9.1
 
   colorette@2.0.20: {}
+
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
 
   comma-separated-tokens@2.0.3: {}
 
@@ -9367,6 +9437,8 @@ snapshots:
       escodegen: 2.1.0
       esprima: 4.0.1
 
+  delayed-stream@1.0.0: {}
+
   dequal@2.0.3: {}
 
   destr@2.0.3: {}
@@ -9425,7 +9497,7 @@ snapshots:
 
   dunder-proto@1.0.1:
     dependencies:
-      call-bind-apply-helpers: 1.0.1
+      call-bind-apply-helpers: 1.0.2
       es-errors: 1.3.0
       gopd: 1.2.0
 
@@ -10137,6 +10209,8 @@ snapshots:
 
   flatted@3.3.3: {}
 
+  follow-redirects@1.16.0: {}
+
   for-each@0.3.5:
     dependencies:
       is-callable: 1.2.7
@@ -10145,6 +10219,14 @@ snapshots:
     dependencies:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
+
+  form-data@4.0.6:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.4
+      mime-types: 2.1.35
 
   fraction.js@4.3.7: {}
 
@@ -10173,19 +10255,6 @@ snapshots:
   gensync@1.0.0-beta.2: {}
 
   get-east-asian-width@1.3.0: {}
-
-  get-intrinsic@1.2.7:
-    dependencies:
-      call-bind-apply-helpers: 1.0.1
-      es-define-property: 1.0.1
-      es-errors: 1.3.0
-      es-object-atoms: 1.1.1
-      function-bind: 1.1.2
-      get-proto: 1.0.1
-      gopd: 1.2.0
-      has-symbols: 1.1.0
-      hasown: 2.0.2
-      math-intrinsics: 1.1.0
 
   get-intrinsic@1.3.0:
     dependencies:
@@ -10343,6 +10412,10 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hasown@2.0.4:
+    dependencies:
+      function-bind: 1.1.2
+
   hast-util-to-estree@3.1.1:
     dependencies:
       '@types/estree': 1.0.6
@@ -10412,6 +10485,13 @@ snapshots:
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.3
+      debug: 4.4.1
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@5.0.1:
+    dependencies:
+      agent-base: 6.0.2
       debug: 4.4.1
     transitivePeerDependencies:
       - supports-color
@@ -10902,6 +10982,14 @@ snapshots:
       react: 19.2.3
 
   macos-release@3.3.0: {}
+
+  mailtrap@4.6.1:
+    dependencies:
+      axios: 1.18.1
+      qs: 6.15.3
+    transitivePeerDependencies:
+      - debug
+      - supports-color
 
   markdown-extensions@2.0.0: {}
 
@@ -11767,6 +11855,8 @@ snapshots:
 
   proxy-from-env@1.1.0: {}
 
+  proxy-from-env@2.1.0: {}
+
   punycode@2.3.1: {}
 
   pupa@3.1.0:
@@ -11778,6 +11868,11 @@ snapshots:
   qs@6.14.0:
     dependencies:
       side-channel: 1.1.0
+
+  qs@6.15.3:
+    dependencies:
+      es-define-property: 1.0.1
+      side-channel: 1.1.1
 
   queue-microtask@1.2.3: {}
 
@@ -12302,21 +12397,26 @@ snapshots:
   side-channel-list@1.0.0:
     dependencies:
       es-errors: 1.3.0
-      object-inspect: 1.13.3
+      object-inspect: 1.13.4
+
+  side-channel-list@1.0.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
 
   side-channel-map@1.0.1:
     dependencies:
-      call-bound: 1.0.3
+      call-bound: 1.0.4
       es-errors: 1.3.0
-      get-intrinsic: 1.2.7
-      object-inspect: 1.13.3
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
 
   side-channel-weakmap@1.0.2:
     dependencies:
-      call-bound: 1.0.3
+      call-bound: 1.0.4
       es-errors: 1.3.0
-      get-intrinsic: 1.2.7
-      object-inspect: 1.13.3
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
       side-channel-map: 1.0.1
 
   side-channel@1.1.0:
@@ -12324,6 +12424,14 @@ snapshots:
       es-errors: 1.3.0
       object-inspect: 1.13.3
       side-channel-list: 1.0.0
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
+
+  side-channel@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 

--- a/src/content/about/1tech-stack.md
+++ b/src/content/about/1tech-stack.md
@@ -13,7 +13,7 @@ title: Tech Stack
 - Analytics: **[Umami](https://umami.is/)**
 - Internationalization: **[Next International](https://next-international.vercel.app/)**
 - Deployment: **[Vercel](https://vercel.com/)**
-- Email: **[Resend](https://resend.com/)**
+- Email: **[Resend](https://resend.com/)** (default) or **[Mailtrap](https://mailtrap.io/)** via `EMAIL_PROVIDER`, with a Mailtrap Sandbox option for local testing
 - Email Template : **[React Email](https://react.email/)**
 - File Storage: **[UploadThing](https://uploadthing.com/)**
 - Linting & Formatting: **[ESLint](https://eslint.org/)** & **[Prettier](https://prettier.io/)**

--- a/src/lib/server/mail.ts
+++ b/src/lib/server/mail.ts
@@ -1,43 +1,136 @@
+import { render } from "@react-email/components";
 import ThanksTemp from "emails/thanks";
 import VerificationTemp from "emails/verification";
+import { MailtrapClient } from "mailtrap";
 import { Resend } from "resend";
 import { type SendOTPProps, type SendWelcomeEmailProps } from "~/types";
 import { generateId } from "../utils";
-import { ReactNode } from "react";
+import { type ReactElement } from "react";
 
-export const resend = new Resend(process.env.RESEND_API_KEY);
+const FROM = { name: "ChadNext App", email: "chadnext@moinulmoin.com" };
+
+// Email provider is selectable via env, with Resend as the default so existing
+// setups keep working with no changes. Set EMAIL_PROVIDER=mailtrap to send through
+// Mailtrap instead. Shortcut: USE_MAILTRAP_SANDBOX=true implies the Mailtrap provider
+// in Sandbox mode — emails are captured in a test inbox instead of being delivered,
+// which is ideal for local development (no spamming real inboxes, no Resend quota use).
+const useMailtrapSandbox = process.env.USE_MAILTRAP_SANDBOX === "true";
+
+const SUPPORTED_PROVIDERS = ["resend", "mailtrap"] as const;
+type Provider = (typeof SUPPORTED_PROVIDERS)[number];
+
+const resolveProvider = (): Provider => {
+  if (useMailtrapSandbox) {
+    return "mailtrap";
+  }
+  const value = (process.env.EMAIL_PROVIDER ?? "resend").toLowerCase();
+  if (!SUPPORTED_PROVIDERS.includes(value as Provider)) {
+    throw new Error(
+      `Unknown EMAIL_PROVIDER "${process.env.EMAIL_PROVIDER}". Supported values: ${SUPPORTED_PROVIDERS.join(", ")}.`
+    );
+  }
+  return value as Provider;
+};
+
+const provider = resolveProvider();
+
+type Email = {
+  toMail: string;
+  subject: string;
+  template: ReactElement;
+};
+
+// Both clients are instantiated lazily and memoized, so selecting one provider never
+// requires the other's credentials (the Resend constructor throws without a key, and
+// Mailtrap requires a token).
+let resendClient: Resend | null = null;
+const getResendClient = () => {
+  if (!resendClient) {
+    resendClient = new Resend(process.env.RESEND_API_KEY);
+  }
+  return resendClient;
+};
+
+let mailtrapClient: MailtrapClient | null = null;
+const getMailtrapClient = () => {
+  if (mailtrapClient) {
+    return mailtrapClient;
+  }
+
+  const token = process.env.MAILTRAP_API_TOKEN;
+  if (!token) {
+    throw new Error(
+      "Mailtrap is selected but MAILTRAP_API_TOKEN is missing. Set it in your .env, or switch EMAIL_PROVIDER back to resend."
+    );
+  }
+
+  if (useMailtrapSandbox) {
+    const inboxId = process.env.MAILTRAP_INBOX_ID;
+    if (!inboxId) {
+      throw new Error(
+        "USE_MAILTRAP_SANDBOX is true but MAILTRAP_INBOX_ID is missing. Set it in your .env or unset USE_MAILTRAP_SANDBOX."
+      );
+    }
+    mailtrapClient = new MailtrapClient({
+      token,
+      sandbox: true,
+      testInboxId: Number(inboxId),
+    });
+  } else {
+    mailtrapClient = new MailtrapClient({ token });
+  }
+
+  return mailtrapClient;
+};
+
+const sendWithResend = async ({ toMail, subject, template }: Email) => {
+  await getResendClient().emails.send({
+    from: `${FROM.name} <${FROM.email}>`,
+    to: toMail,
+    subject,
+    headers: {
+      "X-Entity-Ref-ID": generateId(),
+    },
+    react: template,
+    text: "",
+  });
+};
+
+const sendWithMailtrap = async ({ toMail, subject, template }: Email) => {
+  const html = await render(template);
+
+  await getMailtrapClient().send({
+    from: FROM,
+    to: [{ email: toMail }],
+    subject,
+    html,
+  });
+};
+
+const deliver = async (email: Email) => {
+  if (provider === "mailtrap") {
+    await sendWithMailtrap(email);
+    return;
+  }
+
+  await sendWithResend(email);
+};
 
 export const sendWelcomeEmail = async ({
   toMail,
   userName,
 }: SendWelcomeEmailProps) => {
-  const subject = "Thanks for using ChadNext!";
-  const temp = ThanksTemp({ userName }) as ReactNode;
-
-  await resend.emails.send({
-    from: `ChadNext App <chadnext@moinulmoin.com>`,
-    to: toMail,
-    subject: subject,
-    headers: {
-      "X-Entity-Ref-ID": generateId(),
-    },
-    react: temp,
-    text: "",
+  await deliver({
+    toMail,
+    subject: "Thanks for using ChadNext!",
+    template: ThanksTemp({ userName }) as ReactElement,
   });
 };
 
 export const sendOTP = async ({ toMail, code, userName }: SendOTPProps) => {
-  const subject = "OTP for ChadNext";
-  const temp = VerificationTemp({ userName, code }) as ReactNode;
-
-  await resend.emails.send({
-    from: `ChadNext App <chadnext@moinulmoin.com>`,
-    to: toMail,
-    subject: subject,
-    headers: {
-      "X-Entity-Ref-ID": generateId(),
-    },
-    react: temp,
-    text: "",
+  await deliver({
+    toMail,
+    subject: "OTP for ChadNext",
+    template: VerificationTemp({ userName, code }) as ReactElement,
   });
 };


### PR DESCRIPTION
## What & why

Adds [Mailtrap](https://mailtrap.io/) as an optional email provider alongside the existing [Resend](https://resend.com/) integration. **Resend stays the default and existing setups are completely unaffected** — Mailtrap is purely additive and opt-in.

The main motivation is Mailtrap's **Sandbox**: when running the template locally, you can capture every outgoing email in a test inbox instead of delivering it. That means no spamming real inboxes and no burning your Resend free-tier quota while developing auth flows (OTP, welcome emails).

## How it works

Two env-driven behaviors, both off by default:

- **`EMAIL_PROVIDER`** — defaults to `resend`. Set `EMAIL_PROVIDER=mailtrap` to send through Mailtrap instead. An unknown value throws a clear error rather than silently falling back.
- **`USE_MAILTRAP_SANDBOX=true`** — local-dev shortcut that routes email to a Mailtrap Sandbox test inbox (requires `MAILTRAP_API_TOKEN` + `MAILTRAP_INBOX_ID`).

Implementation notes:
- The existing React Email templates are rendered to HTML (via `render()` from `@react-email/components`, already a dependency) for the Mailtrap path. The Resend path is unchanged and still passes the React component directly.
- Both provider clients are lazily instantiated, so selecting one never requires the other's credentials.
- Public function signatures (`sendOTP`, `sendWelcomeEmail`) are unchanged — no call sites needed edits.

Note: live (non-sandbox) Mailtrap sending requires a verified sending domain and a matching `FROM` in `src/lib/server/mail.ts` — documented in `example.env` and the README. Sandbox mode needs no domain setup.

## Testing

Verified end-to-end against a live Mailtrap account:
- Default (no env) → routes to Resend, untouched.
- `EMAIL_PROVIDER=mailtrap` → routes to Mailtrap's production API.
- `USE_MAILTRAP_SANDBOX=true` → real email delivered to the Sandbox inbox; rendered HTML confirmed to contain the OTP code, personalized greeting, and branding.
- Unknown `EMAIL_PROVIDER` → throws the expected error.

## Files changed

- `src/lib/server/mail.ts` — provider selection + Mailtrap sender
- `example.env` — documented `EMAIL_PROVIDER`, `USE_MAILTRAP_SANDBOX`, `MAILTRAP_API_TOKEN`, `MAILTRAP_INBOX_ID`
- `package.json` / `pnpm-lock.yaml` — add `mailtrap` dependency
- `README.md`, `src/content/about/1tech-stack.md` — docs